### PR TITLE
remove redundant add path and rmpath to resolve jpeg_read error

### DIFF
--- a/EvaluateAlgorithm.m
+++ b/EvaluateAlgorithm.m
@@ -1,7 +1,4 @@
 clear all;
-addpath(['.' filesep 'Util' filesep]);
-addpath(['.' filesep 'Util/jpeg_toolbox' filesep])
-addpath(['.' filesep 'Util/jpeg_toolbox/jpegtbx_1.4' filesep]);
 
 % File Paths:
 rootPath=pwd;
@@ -57,7 +54,3 @@ for i = 1:length(algorithmNames)
     disp(['True Positives at 5% False Positives: ' num2str(TP_at_05*100) '%']);
     
 end
-
-% Remove paths only once after processing all algorithms
-rmpath(['.' filesep 'Util/jpeg_toolbox/jpegtbx_1.4' filesep])
-rmpath(['.' filesep 'Util/jpeg_toolbox' filesep]);


### PR DESCRIPTION
Encountering a `jpeg_Read` error when `EvaluateAlgorithm.m` script is trying to run Algorithm ADQ2. The error occurs due to an issue with function execution and directory path settings.

## Error message:
```Execution of script jpeg_read as a function is not supported:
C:\Users\GenAI-Image-Forensics-Toolbox\Util\jpegtbx_1.4\jpeg_read.m

Error in analyze (line 6)
im = jpeg_read(imPath);
^^^^^^^^^^^^^^^^^

Error in ExtractMaps (line 27)
Result=analyze(SplicedList{FileInd});
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

Error in EvaluateAlgorithm (line 36)
ExtractMaps(Options,one_mask);
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

## Additional Warning:
```Warning: Name is nonexistent or not a directory:
C:\Users\1-Github\GenAI-Image-Forensics-Toolbox\.\Util\jpeg_toolbox\jpegtbx_1.4

> In path (line 109)
In addpath>doPathAddition (line 126)
In addpath (line 90)
In EvaluateAlgorithm (line 4)
>
```

## Issue Identification:
The problem originates from line 4 in `EvaluateAlgorithm.m`:
```MATLAB
addpath(['.' filesep 'Util/jpeg_toolbox/jpegtbx_1.4' filesep]);
```
- If jpegtbx_1.4 is missing from the jpeg_toolbox directory, a warning occurs, but the program continues to run correctly as long as it has been declared within the `set path` option.
- However, if the path is corrected in line 4 or jpegtbx_1.4 is placed in the expected directory, the error message appears and the script won't run, even if it is correctly declared within the `set path` option.
